### PR TITLE
Extend policy to cover other deployment kinds

### DIFF
--- a/library/pod-security-policy/windows-runasusername/samples/psps-windows-runasusername/constraint.yaml
+++ b/library/pod-security-policy/windows-runasusername/samples/psps-windows-runasusername/constraint.yaml
@@ -5,8 +5,8 @@ metadata:
 spec:
   match:
     kinds:
-      - apiGroups: [""]
-        kinds: ["Pod"]
+      - apiGroups: ["","apps","batch"]
+        kinds: ["Pod","Deployment","StatefulSet","ReplicationController","ReplicaSet","DaemonSet","Job"]
     namespaces:
       - "default"
   parameters:

--- a/library/pod-security-policy/windows-runasusername/template.yaml
+++ b/library/pod-security-policy/windows-runasusername/template.yaml
@@ -9,13 +9,13 @@ spec:
     spec:
       names:
         kind: K8sDisallowedRunAsUserNames
-    validation:
-      openAPIV3Schema:
-        properties:
-          disallowedUserNames:
-            type: array
-            items:
-              type: string
+      validation:
+        openAPIV3Schema:
+          properties:
+            disallowedUserNames:
+              type: array
+              items:
+                type: string
   targets:
   - target: admission.k8s.gatekeeper.sh
     rego: |
@@ -46,6 +46,19 @@ spec:
           out = un
       }
 
+      # returns runAsUserName if set for container
+      get_username(c) = out {
+          un := c.securityContext.windowsOptions.runAsUserName
+          out = un
+      }
+
+      # returns runAsUserName if NOT set for container but IS set for pod
+      get_username(c) = out {
+          not has_username_set_for_container(c)
+          un := input.review.object.spec.template.spec.securityContext.windowsOptions.runAsUserName
+          out = un
+      }
+
       has_username_set_for_container(c) {
           c.securityContext.windowsOptions.runAsUserName
       }
@@ -55,8 +68,17 @@ spec:
           ns["kubernetes.io/os"] == "windows"
       }
 
+      isWindowsPod {
+          ns := input.review.object.spec.template.spec.nodeSelector
+          ns["kubernetes.io/os"] == "windows"
+      }
+
       input_containers[c] {
           c := input.review.object.spec.containers[_]
+      }
+
+      input_containers[c] {
+          c := input.review.object.spec.template.spec.containers[_]
       }
 
       input_containers[c] {

--- a/src/pod-security-policy/windows-runasusername/src.rego
+++ b/src/pod-security-policy/windows-runasusername/src.rego
@@ -25,6 +25,19 @@ get_username(c) = out {
     out = un
 }
 
+# returns runAsUserName if set for container
+get_username(c) = out {
+    un := c.securityContext.windowsOptions.runAsUserName
+    out = un
+}
+
+# returns runAsUserName if NOT set for container but IS set for pod
+get_username(c) = out {
+    not has_username_set_for_container(c)
+    un := input.review.object.spec.template.spec.securityContext.windowsOptions.runAsUserName
+    out = un
+}
+
 has_username_set_for_container(c) {
     c.securityContext.windowsOptions.runAsUserName
 }
@@ -34,8 +47,17 @@ isWindowsPod {
     ns["kubernetes.io/os"] == "windows"
 }
 
+isWindowsPod {
+    ns := input.review.object.spec.template.spec.nodeSelector
+    ns["kubernetes.io/os"] == "windows"
+}
+
 input_containers[c] {
     c := input.review.object.spec.containers[_]
+}
+
+input_containers[c] {
+    c := input.review.object.spec.template.spec.containers[_]
 }
 
 input_containers[c] {


### PR DESCRIPTION
Hey Mark,

thanks for providing your changes - they helped a lot to get forward with mixed cluster setups.

I was wondering why the policies only cover Pod deployments.
I need to cover all kind of deployments so I did following modifications.

Best
Patrick